### PR TITLE
Add navigation between pages

### DIFF
--- a/project/app/build.gradle.kts
+++ b/project/app/build.gradle.kts
@@ -41,6 +41,7 @@ android {
 
 dependencies {
 
+    implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
@@ -49,6 +50,10 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.appcompat)
+    implementation(libs.material)
+    implementation(libs.androidx.activity)
+    implementation(libs.androidx.constraintlayout)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/project/app/src/main/AndroidManifest.xml
+++ b/project/app/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
         android:theme="@style/Theme.Mobileproject"
         tools:targetApi="31">
         <activity
+            android:name=".RoutineList"
+            android:exported="false" />
+        <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"

--- a/project/app/src/main/AndroidManifest.xml
+++ b/project/app/src/main/AndroidManifest.xml
@@ -13,9 +13,6 @@
         android:theme="@style/Theme.Mobileproject"
         tools:targetApi="31">
         <activity
-            android:name=".RoutineList"
-            android:exported="false" />
-        <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"

--- a/project/app/src/main/java/com/project/mobile/MainActivity.kt
+++ b/project/app/src/main/java/com/project/mobile/MainActivity.kt
@@ -3,45 +3,37 @@ package com.project.mobile
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.compose.runtime.LaunchedEffect
 import com.project.mobile.ui.theme.MobileprojectTheme
+import androidx.navigation.compose.rememberNavController
+import com.project.mobile.ui.RoutineFormPage
+import com.project.mobile.ui.RoutineListPage
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
         setContent {
             MobileprojectTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+                // 1. Create the navController
+                val navController = rememberNavController()
+
+                // 2. Map all pages to route in the navController
+                NavHost(navController = navController, startDestination = "routine_list") {
+                    composable("routine_list") {
+                        RoutineListPage(navController)
+                    }
+                    composable("routine_form/{routineId}") { backStackEntry ->
+                        RoutineFormPage(navController, routineId = backStackEntry.arguments?.getString("routineId"))
+                    }
+                }
+
+                // 3. Once finished, redirect to routine list page
+                LaunchedEffect(Unit) {
+                    navController.navigate("routine_list")
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    MobileprojectTheme {
-        Greeting("Android")
     }
 }

--- a/project/app/src/main/java/com/project/mobile/ui/RoutineFormPage.kt
+++ b/project/app/src/main/java/com/project/mobile/ui/RoutineFormPage.kt
@@ -1,0 +1,48 @@
+package com.project.mobile.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+
+@Composable
+fun RoutineFormPage(navController: NavController, routineId: String?) {
+    Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+        RoutineForm(
+            navController = navController,
+            name = "RoutineFormPage",
+            routineId = routineId,
+            modifier = Modifier.padding(innerPadding)
+        )
+    }
+}
+
+@Composable
+fun RoutineForm(navController: NavController, name: String, routineId: String?, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp), // optional padding
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Hello $name! We are editing $routineId",
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        Button(onClick = {
+            navController.navigate("routine_list")
+        }) {
+            Text(text = "Go to RoutineListPage")
+        }
+    }
+}

--- a/project/app/src/main/java/com/project/mobile/ui/RoutineListPage.kt
+++ b/project/app/src/main/java/com/project/mobile/ui/RoutineListPage.kt
@@ -1,0 +1,48 @@
+package com.project.mobile.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+
+//TODO This is where we want to display the list of routine available
+@Composable
+fun RoutineListPage(navController: NavController) {
+    Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+        RoutineList(
+            navController = navController,
+            name = "RoutineListPage",
+            modifier = Modifier.padding(innerPadding)
+        )
+    }
+}
+
+@Composable
+fun RoutineList(navController: NavController, name: String, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Hello $name!",
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        Button(onClick = {
+            navController.navigate("routine_form/1")
+        }) {
+            Text(text = "Go to RoutineFormPage")
+        }
+    }
+}

--- a/project/app/src/main/res/layout/activity_routine_list.xml
+++ b/project/app/src/main/res/layout/activity_routine_list.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".RoutineList">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/project/gradle/libs.versions.toml
+++ b/project/gradle/libs.versions.toml
@@ -8,9 +8,15 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.0"
 composeBom = "2024.04.01"
+appcompat = "1.6.1"
+material = "1.10.0"
+activity = "1.10.0"
+constraintlayout = "2.1.4"
+navigationCompose = "2.8.5"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
@@ -24,6 +30,10 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
# Information
This pr add navigation between pages in the project.
It initiate the navManager and passes it to both component that will become edit and list page

> [!WARNING]
> This PR contains element that will need to be removed. They were added to test the navigation and make sure it works correctly.

# Technicalities
- The components for the list and page were added in this, even tho they are not part of the task. This was done to avoid adding the link to them later.
- The structure may be subject to change, but we will just have to change the routing in `MainActivity`

![image](https://github.com/user-attachments/assets/55e86510-2368-4ef2-858b-a613e303a1ee)

# Test plan
- Launch the application.
- [ ] Expect to be on the routineList page.
- Click the button.
- [ ] Expect to be on the routineForm page.
- Click the button.
- [ ] Expect to be back to the routineList page.